### PR TITLE
Use https as required by the recent API change

### DIFF
--- a/lib/screenshot/client.rb
+++ b/lib/screenshot/client.rb
@@ -1,7 +1,7 @@
 module Screenshot
 	class Client
           
-    API = "http://www.browserstack.com/screenshots"
+    API = "https://www.browserstack.com/screenshots"
     
     def initialize(options={})
       options = symbolize_keys options
@@ -61,6 +61,7 @@ module Screenshot
 
     def make_request req, options={}, uri=API
       conn = Net::HTTP.new uri.host, uri.port
+      conn.use_ssl = uri.scheme == 'https'
       add_authentication options, req
       res = conn.request req
       http_response_code_check res


### PR DESCRIPTION
This change resolves #4 by updating the API URL to use https instead of http. SSL is now required by the BrowserStack API, and this gem does not follow http-to-https redirects.