### PR TITLE
Update ruby-yajl to support Ruby 2.4 

### DIFF
--- a/browserstack-screenshot.gemspec
+++ b/browserstack-screenshot.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
-  spec.add_dependency("yajl-ruby", "1.1.0")
+  spec.add_dependency("yajl-ruby", "1.3.0")
 end


### PR DESCRIPTION
Bump yajl-ruby dependency to v1.3.0.

https://github.com/brianmario/yajl-ruby/pull/165
