### PR TITLE
LIVE-20569: Pin semgrep CI container image to tag + digest (F-008)

### DIFF
--- a/.github/workflows/Semgrep.yml
+++ b/.github/workflows/Semgrep.yml
@@ -27,7 +27,10 @@ jobs:
 
     container:
       # A Docker image with Semgrep installed. Do not change this.
-      image: returntocorp/semgrep
+      # Pinned to a specific tag + immutable digest to prevent supply-chain
+      # tampering via floating tag mutation. Bump both the tag and the
+      # digest together when updating.
+      image: returntocorp/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03
 
     # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')


### PR DESCRIPTION
## Summary
Pins the Semgrep container image used by `.github/workflows/Semgrep.yml` from the unpinned floating `returntocorp/semgrep` (resolves to `:latest`) to the immutable `returntocorp/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03`. Matches the SHA-pinning pattern already used for the `actions/checkout` and `codeql-action/upload-sarif` steps in the same workflow.

Closes [LIVE-20569](https://browserstack.atlassian.net/browse/LIVE-20569) (F-008 — CI workflow uses unpinned floating Docker image tag).

## Why
A floating `:latest` tag lets the image publisher (or anyone with publish access compromised) push an updated image that CI silently picks up on the next run, potentially exfiltrating repo contents or secrets. Pinning to a digest makes the image bit-for-bit immutable.

## Risk
Very low. Semgrep 1.163.0 is the current latest stable release (digest verified against Docker Hub at PR time). Bumping requires updating both the tag and digest together.

## Test plan
- [ ] Semgrep workflow runs successfully on this PR.
- [ ] Image pull resolves to the pinned digest (visible in the workflow's "Initialize containers" step).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

[LIVE-20569]: https://browserstack.atlassian.net/browse/LIVE-20569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ